### PR TITLE
Fix _get_latest_release_url()

### DIFF
--- a/vswhere/__init__.py
+++ b/vswhere/__init__.py
@@ -303,7 +303,7 @@ def _get_latest_release_url():
     try:
         from urllib.request import urlopen
         with urlopen(LATEST_RELEASE_ENDPOINT) as response:
-            release = json.loads(response.read(), encoding=response.headers.get_content_charset() or 'utf-8')
+            release = json.loads(response.read())
     except ImportError:
         # Python 2
         import urllib2


### PR DESCRIPTION
``_get_latest_release_url()`` doesn't work in Python 3.9 because ``json.loads`` uses removed in Python 3.9 argument ``encoding``. 

From Python 3.9 changelog:
>The encoding parameter of json.loads() has been removed. As of Python 3.1, it was deprecated and ignored; using it has emitted a DeprecationWarning since Python 3.8.